### PR TITLE
Fix using cache of PEG.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -217,7 +217,7 @@ module.exports = function (grunt) {
 			"pegjs": {
 				cmd: function () {
 					var peg = grunt.config.get("opt.client.peg") + "/";
-					return "./node_modules/.bin/pegjs " + peg + "/grammar.pegjs " + peg + "/grammar.js";
+					return "./node_modules/.bin/pegjs --cache " + peg + "/grammar.pegjs " + peg + "/grammar.js";
 				}
 			}
 		}


### PR DESCRIPTION
PEG.jsでcacheオプションを使うように修正しました。これでパースの速度が速くなると思います。

参考
* https://github.com/pegjs/pegjs/issues/213
* http://pegjs.org/documentation